### PR TITLE
docs(component): Declare non-empty-string as return type

### DIFF
--- a/src/Identifier.php
+++ b/src/Identifier.php
@@ -23,6 +23,8 @@ interface Identifier
 
     /**
      * Returns a string representation of the identifier
+     *
+     * @return non-empty-string
      */
     public function toString(): string;
 }


### PR DESCRIPTION
## Description
This proposed change adds `non-empty-string` as return type, since as far as my understanding goes, there will be no implementing instances returning empty string.

## Motivation and context
During an experiment with the UUIDV7 of the `ramsey/identifier` package, PHPStan flagged its call to `toString` method as not returning `non-empty-string`, which is the type one of the components I was working on expects.

## How has this been tested?
Static analysis

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
